### PR TITLE
chore: rebranding distribution to new name

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -57,7 +57,7 @@ If you are opening a Draft PR, you can use the checklist to track the tests that
 have performed them.
 Example:
 
-- [ ] Tested the change with KFD version X.Y.Z
+- [ ] Tested the change with SKD version X.Y.Z
 - [ ] Tested an upgrade from the previous version X
 -->
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 <!-- markdownlint-disable MD033 -->
-<h1>
-    <img src="https://raw.githubusercontent.com/sighupio/distribution/refs/heads/feat/rebranding/docs/assets/white-logo.png" align="left" width="90" style="margin-right: 15px"/>
-    Module Auth
+<h1 align="center">
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/sighupio/distribution/refs/heads/main/docs/assets/white-logo.png">
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/sighupio/distribution/refs/heads/main/docs/assets/black-logo.png">
+  <img alt="Shows a black logo in light color mode and a white one in dark color mode." src="https://raw.githubusercontent.com/sighupio/distribution/refs/heads/main/docs/assets/white-logo.png">
+</picture><br/>
+  Auth Module
 </h1>
 <!-- markdownlint-enable MD033 -->
 
@@ -11,17 +15,17 @@
 
 <!-- <KFD-DOCS> -->
 
-**Module Auth** provides Authentication Management for [SIGHUP Distribution (SKD)][skd-repo].
+**Auth Module** provides Authentication Management for [SIGHUP Distribution (SKD)][skd-repo].
 
 If you are new to SKD please refer to the [official documentation][skd-docs] on how to get started with the distribution.
 
 ## Overview
 
-**Module Auth** uses CNCF recommended, Cloud Native projects, such as the [Dex][dex-repo] identity provider, and [Pomerium][pomerium-repo] as an identity-aware proxy to enable secure access to internal applications.
+**Auth Module** uses CNCF recommended, Cloud Native projects, such as the [Dex][dex-repo] identity provider, and [Pomerium][pomerium-repo] as an identity-aware proxy to enable secure access to internal applications.
 
 ## Packages
 
-Module Auth provides the following packages:
+Auth Module provides the following packages:
 
 | Package                        | Version   | Description                                                               |
 | ------------------------------ | --------- | ------------------------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -1,27 +1,27 @@
 <!-- markdownlint-disable MD033 -->
 <h1>
-    <img src="https://github.com/sighupio/fury-distribution/blob/main/docs/assets/fury-epta-white.png?raw=true" align="left" width="90" style="margin-right: 15px"/>
-    Kubernetes Fury Auth
+    <img src="https://raw.githubusercontent.com/sighupio/distribution/refs/heads/feat/rebranding/docs/assets/white-logo.png" align="left" width="90" style="margin-right: 15px"/>
+    Module Auth
 </h1>
 <!-- markdownlint-enable MD033 -->
 
 ![Release](https://img.shields.io/badge/Latest%20Release-v0.5.0-blue)
-![License](https://img.shields.io/github/license/sighupio/fury-kubernetes-auth?label=License)
+![License](https://img.shields.io/github/license/sighupio/module-auth?label=License)
 ![Slack](https://img.shields.io/badge/slack-@kubernetes/fury-yellow.svg?logo=slack&label=Slack)
 
 <!-- <KFD-DOCS> -->
 
-**Kubernetes Fury Auth** provides Authentication Management for [Kubernetes Fury Distribution (KFD)][kfd-repo].
+**Module Auth** provides Authentication Management for [SIGHUP Distribution (SKD)][skd-repo].
 
-If you are new to KFD please refer to the [official documentation][kfd-docs] on how to get started with the distribution.
+If you are new to SKD please refer to the [official documentation][skd-docs] on how to get started with the distribution.
 
 ## Overview
 
-**Kubernetes Fury Auth** uses CNCF recommended, Cloud Native projects, such as the [Dex][dex-repo] identity provider, and [Pomerium][pomerium-repo] as an identity-aware proxy to enable secure access to internal applications.
+**Module Auth** uses CNCF recommended, Cloud Native projects, such as the [Dex][dex-repo] identity provider, and [Pomerium][pomerium-repo] as an identity-aware proxy to enable secure access to internal applications.
 
 ## Packages
 
-Kubernetes Fury Auth provides the following packages:
+Module Auth provides the following packages:
 
 | Package                        | Version   | Description                                                               |
 | ------------------------------ | --------- | ------------------------------------------------------------------------- |
@@ -52,7 +52,7 @@ Check the [compatibility matrix][compatibility-matrix] for additional informatio
 
 | Tool                        | Version   | Description                                                                                                                                                    |
 | --------------------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [furyctl][furyctl-repo]     | `>=0.6.0` | The recommended tool to download and manage KFD modules and their packages. To learn more about `furyctl` read the [official documentation][furyctl-repo].     |
+| [furyctl][furyctl-repo]     | `>=0.6.0` | The recommended tool to download and manage SKD modules and their packages. To learn more about `furyctl` read the [official documentation][furyctl-repo].     |
 | [kustomize][kustomize-repo] | `>=3.5.0` | Packages are customized using `kustomize`. To learn how to create your customization layer with `kustomize`, please refer to the [repository][kustomize-repo]. |
 
 ### Deployment with legacy furyctl
@@ -105,12 +105,12 @@ kustomize build . | kubectl apply -f -
 
 ### Monitoring
 
-KFD Auth module integrates out-of-the-box with KFD's Monitoring module. Providing metrics and dashboards to visualize the status of its components.
+SKD Auth module integrates out-of-the-box with SKD's Monitoring module. Providing metrics and dashboards to visualize the status of its components.
 
 In particular:
 
-- Dex exposes standard Go adapter metrics, the metrics are automatically scrapped by Prometheus when using KFD Monitoring module but there are no Grafana dashboards nor alerts defined.
-- Pomerium exposes several metrics about Pomerium itself and its underlying envoy proxy. Metrics are scrapped automatically by Prometheus and 2 Grafana dashboards are available with the `pomerium` tag when using KFD Monitoring module. Here are some screenshots:
+- Dex exposes standard Go adapter metrics, the metrics are automatically scrapped by Prometheus when using SKD Monitoring module but there are no Grafana dashboards nor alerts defined.
+- Pomerium exposes several metrics about Pomerium itself and its underlying envoy proxy. Metrics are scrapped automatically by Prometheus and 2 Grafana dashboards are available with the `pomerium` tag when using SKD Monitoring module. Here are some screenshots:
 
 <!-- markdownlint-disable MD033 -->
 
@@ -140,10 +140,10 @@ In particular:
 <!-- Links -->
 
 [furyctl-repo]: https://github.com/sighupio/furyctl
-[kfd-repo]: https://github.com/sighupio/fury-distribution
+[skd-repo]: https://github.com/sighupio/distribution
 [kustomize-repo]: https://github.com/kubernetes-sigs/kustomize
-[kfd-docs]: https://docs.kubernetesfury.com/docs/distribution/
-[compatibility-matrix]: https://github.com/sighupio/fury-kubernetes-auth/blob/master/docs/COMPATIBILITY_MATRIX.md
+[skd-docs]: https://docs.kubernetesfury.com/docs/distribution/
+[compatibility-matrix]: https://github.com/sighupio/module-auth/blob/master/docs/COMPATIBILITY_MATRIX.md
 [pomerium-repo]: https://github.com/pomerium/pomerium
 [dex-repo]: https://github.com/dexidp/dex
 
@@ -157,7 +157,7 @@ Before contributing, please read first the [Contributing Guidelines](docs/CONTRI
 
 ### Reporting Issues
 
-In case you experience any problems with the module, please [open a new issue](https://github.com/sighupio/fury-kubernetes-auth/issues/new/choose).
+In case you experience any problems with the module, please [open a new issue](https://github.com/sighupio/module-auth/issues/new/choose).
 
 ## License
 

--- a/docs/releases/v0.0.1.md
+++ b/docs/releases/v0.0.1.md
@@ -1,4 +1,4 @@
-# Module Auth add-on module v0.0.1
+# Auth Module add-on module v0.0.1
 
 This is a maintenance release of the new `auth` module.
 

--- a/docs/releases/v0.0.1.md
+++ b/docs/releases/v0.0.1.md
@@ -1,4 +1,4 @@
-# Kubernetes Fury Auth add-on module v0.0.1
+# Module Auth add-on module v0.0.1
 
 This is a maintenance release of the new `auth` module.
 

--- a/docs/releases/v0.0.2.md
+++ b/docs/releases/v0.0.2.md
@@ -1,4 +1,4 @@
-# Module Auth module v0.0.2
+# Auth Module module v0.0.2
 
 This is a maintenance release of the `auth` module.
 

--- a/docs/releases/v0.0.2.md
+++ b/docs/releases/v0.0.2.md
@@ -1,8 +1,8 @@
-# Kubernetes Fury Auth module v0.0.2
+# Module Auth module v0.0.2
 
 This is a maintenance release of the `auth` module.
 
-This release inlcudes compatbility with latest Kubernetes versions. An update to Dex and custom HTLM templates for Gangway's pages with Fury's branding.
+This release inlcudes compatbility with latest Kubernetes versions. An update to Dex and custom HTLM templates for Gangway's pages with SKD's branding.
 
 ## Included packages
 
@@ -18,7 +18,7 @@ This release inlcudes compatbility with latest Kubernetes versions. An update to
 
 To upgrade this module from `v0.0.1` to `v0.0.2`, you need to download this new version, then apply the `kustomize` project. No further action is required.
 
-> 💡 Be sure to enable the `customHTMLTemplatesDir: /custom-templates` config option in Gangway's configuration to use the Fury branded templates.
+> 💡 Be sure to enable the `customHTMLTemplatesDir: /custom-templates` config option in Gangway's configuration to use the SKD branded templates.
 > See the [example config file](../../katalog/gangway/example/gangway.yml).
 
 ```bash

--- a/docs/releases/v0.0.3.md
+++ b/docs/releases/v0.0.3.md
@@ -1,4 +1,4 @@
-# Module Auth Release v0.0.3
+# Auth Module Release v0.0.3
 
 Welcome to the latest release of the Auth module for the SIGHUP Distribution.
 

--- a/docs/releases/v0.0.3.md
+++ b/docs/releases/v0.0.3.md
@@ -1,6 +1,6 @@
-# Auth Module Release v0.0.3
+# Module Auth Release v0.0.3
 
-Welcome to the latest release of the Auth module for the Kubernetes Fury Distribution.
+Welcome to the latest release of the Auth module for the SIGHUP Distribution.
 
 This is a maintenance release to update the Pomerium package. This update includes [breaking changes](#breaking-changes-) in Pomerium.
 
@@ -22,7 +22,7 @@ This is a maintenance release to update the Pomerium package. This update includ
 There are three breaking changes in this version:
 
 1. Pomerium has deprecated the [`policy`](https://www.pomerium.com/docs/reference/policy/policy) field in the configuration in favour of [`routes`](https://www.pomerium.com/docs/reference/routes). You'll need to adapt your policy file to the new format.
-2. Value of `grpc_address` in Pomerium's configuration must be different form `address`. See the [example policy](https://github.com/sighupio/fury-kubernetes-auth/blob/v0.0.3/katalog/pomerium/config/policy.example.yaml).
+2. Value of `grpc_address` in Pomerium's configuration must be different form `address`. See the [example policy](https://github.com/sighupio/module-auth/blob/v0.0.3/katalog/pomerium/config/policy.example.yaml).
 3. Forward mode has been deprecated in Pomerium 0.21.
 
 Continue reading the update guide section to learn more.

--- a/docs/releases/v0.0.4.md
+++ b/docs/releases/v0.0.4.md
@@ -1,4 +1,4 @@
-# Module Auth Release v0.0.4
+# Auth Module Release v0.0.4
 
 Welcome to the latest release of the Auth module for the SIGHUP Distribution.
 

--- a/docs/releases/v0.0.4.md
+++ b/docs/releases/v0.0.4.md
@@ -1,6 +1,6 @@
-# Auth Module Release v0.0.4
+# Module Auth Release v0.0.4
 
-Welcome to the latest release of the Auth module for the Kubernetes Fury Distribution.
+Welcome to the latest release of the Auth module for the SIGHUP Distribution.
 
 ## Included packages
 

--- a/docs/releases/v0.1.0.md
+++ b/docs/releases/v0.1.0.md
@@ -1,4 +1,4 @@
-# Module Auth Release v0.1.0
+# Auth Module Release v0.1.0
 
 Welcome to the latest release of the Auth module for the SIGHUP Distribution.
 

--- a/docs/releases/v0.1.0.md
+++ b/docs/releases/v0.1.0.md
@@ -1,6 +1,6 @@
-# Auth Module Release v0.1.0
+# Module Auth Release v0.1.0
 
-Welcome to the latest release of the Auth module for the Kubernetes Fury Distribution.
+Welcome to the latest release of the Auth module for the SIGHUP Distribution.
 
 ## Included packages
 

--- a/docs/releases/v0.2.0.md
+++ b/docs/releases/v0.2.0.md
@@ -1,6 +1,6 @@
-# Auth Module Release v0.2.0
+# Module Auth Release v0.2.0
 
-Welcome to the latest release of the Auth module for the Kubernetes Fury Distribution.
+Welcome to the latest release of the Auth module for the SIGHUP Distribution.
 
 ## Included packages
 

--- a/docs/releases/v0.2.0.md
+++ b/docs/releases/v0.2.0.md
@@ -1,4 +1,4 @@
-# Module Auth Release v0.2.0
+# Auth Module Release v0.2.0
 
 Welcome to the latest release of the Auth module for the SIGHUP Distribution.
 

--- a/docs/releases/v0.3.0.md
+++ b/docs/releases/v0.3.0.md
@@ -1,6 +1,6 @@
-# Auth Module Release v0.3.0
+# Module Auth Release v0.3.0
 
-Welcome to the latest release of the Auth module for the Kubernetes Fury Distribution.
+Welcome to the latest release of the Auth module for the SIGHUP Distribution.
 
 This release updates Gangplank to version 1.1.0 and adds a new custom branding to Dex.
 

--- a/docs/releases/v0.3.0.md
+++ b/docs/releases/v0.3.0.md
@@ -1,4 +1,4 @@
-# Module Auth Release v0.3.0
+# Auth Module Release v0.3.0
 
 Welcome to the latest release of the Auth module for the SIGHUP Distribution.
 

--- a/docs/releases/v0.4.0.md
+++ b/docs/releases/v0.4.0.md
@@ -1,6 +1,6 @@
-# Auth Module Release v0.4.0
+# Module Auth Release v0.4.0
 
-Welcome to the latest release of the Auth module for the Kubernetes Fury Distribution.
+Welcome to the latest release of the Auth module for the SIGHUP Distribution.
 
 This release updates all the packages versions to the latest available in upstream and improves the security posture of all the packages, making them compliant with the `restricted` Pod Security Standards.
 

--- a/docs/releases/v0.4.0.md
+++ b/docs/releases/v0.4.0.md
@@ -1,4 +1,4 @@
-# Module Auth Release v0.4.0
+# Auth Module Release v0.4.0
 
 Welcome to the latest release of the Auth module for the SIGHUP Distribution.
 

--- a/docs/releases/v0.5.0.md
+++ b/docs/releases/v0.5.0.md
@@ -1,6 +1,6 @@
-# Auth Module Release v0.5.0
+# Module Auth Release v0.5.0
 
-Welcome to the latest release of the Auth module for the Kubernetes Fury Distribution.
+Welcome to the latest release of the Auth module for the SIGHUP Distribution.
 
 This release updates the packages versions of dex and pomerium to the latest available in upstream.
 

--- a/docs/releases/v0.5.0.md
+++ b/docs/releases/v0.5.0.md
@@ -1,4 +1,4 @@
-# Module Auth Release v0.5.0
+# Auth Module Release v0.5.0
 
 Welcome to the latest release of the Auth module for the SIGHUP Distribution.
 

--- a/katalog/gangplank/MAINTENANCE.md
+++ b/katalog/gangplank/MAINTENANCE.md
@@ -2,4 +2,4 @@
 
 There's no upstream to follow.
 
-The HTML templates are custom made to follow the Fury Desing System.
+The HTML templates are custom made to follow the SKD Desing System.

--- a/katalog/pomerium/MAINTENANCE.md
+++ b/katalog/pomerium/MAINTENANCE.md
@@ -15,7 +15,7 @@ To update the Pomerium package, follow the next steps:
 
 1. The manifests for Pomerium are custom, there is no upstream to follow. Read carefully the release notes from upstream and adjust the manifests.
 2. Update the documentation.
-3. Sync the new image tag to Fury's registry.
+3. Sync the new image tag to SKD's registry.
 
 ### Monitoring
 


### PR DESCRIPTION
### Summary 💡

The goal of this PR is to rebrand Kubernetes Fury Distribution (KFD) to SIGHUP Distribution (SKD).

### Tests performed 🧪

No tests are needed.