### PR TITLE
Update gangplank to fix OIDC refresh-token flows with self signed certificates

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -8,9 +8,9 @@ This release updates the package versions of Gangplank to the latest available.
 
 | Package     | Current Version                                                        | Previous Version |
 | ----------- | ---------------------------------------------------------------------- | ---------------- |
-| `dex`       | [`v2.42.0`](https://github.com/dexidp/dex/releases/tag/v2.42.0)        | `v2.41.1`        |
+| `dex`       | [`v2.42.0`](https://github.com/dexidp/dex/releases/tag/v2.42.0)        | No update      |
 | `gangplank` | [`v1.1.1`](https://github.com/sighupio/gangplank/releases/tag/v1.1.1)  | `v1.1.0`         |
-| `pomerium`  | [`v0.28.0`](https://github.com/pomerium/pomerium/releases/tag/v0.28.0) | `v0.27.1`        |
+| `pomerium`  | [`v0.28.0`](https://github.com/pomerium/pomerium/releases/tag/v0.28.0) | No update      |
 
 ## Bug fixes 🐞
 

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,0 +1,23 @@
+# Auth Module Release vTBD
+
+Welcome to the latest release of the Auth module for the SIGHUP Distribution.
+
+This release updates the package versions of Gangplank to the latest available.
+
+## Included packages
+
+| Package     | Current Version                                                        | Previous Version |
+| ----------- | ---------------------------------------------------------------------- | ---------------- |
+| `dex`       | [`v2.42.0`](https://github.com/dexidp/dex/releases/tag/v2.42.0)        | `v2.41.1`        |
+| `gangplank` | [`v1.1.1`](https://github.com/sighupio/gangplank/releases/tag/v1.1.1)  | `v1.1.0`         |
+| `pomerium`  | [`v0.28.0`](https://github.com/pomerium/pomerium/releases/tag/v0.28.0) | `v0.27.1`        |
+
+## Update Guide 🦮
+
+### Process
+
+To upgrade this module from `v0.4.0` to `v0.5.0`, you need to download this new version, then apply the `kustomize` project. No further action is required.
+
+```bash
+kustomize build | kubectl apply -f -
+```

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -12,6 +12,13 @@ This release updates the package versions of Gangplank to the latest available.
 | `gangplank` | [`v1.1.1`](https://github.com/sighupio/gangplank/releases/tag/v1.1.1)  | `v1.1.0`         |
 | `pomerium`  | [`v0.28.0`](https://github.com/pomerium/pomerium/releases/tag/v0.28.0) | `v0.27.1`        |
 
+## Bug fixes 🐞
+
+- [[#42](https://github.com/sighupio/module-auth/pull/42)] Fix OIDC refresh-token flows: Gangplank can now include the Identity Provider's TLS certificate in the generated kubeconfig.
+This fixes broken refresh-token flows when the IDP exposes a self-signed certificate.
+  
+  To use this feature, mount the IDP certificate inside the container and configure the parameter `idpCaPath` in the yaml configuration file or the `GANGPLANK_CONFIG_IDP_CA_PATH` environment variable.
+
 ## Update Guide 🦮
 
 ### Process

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -16,7 +16,7 @@ This release updates the package versions of Gangplank to the latest available.
 
 ### Process
 
-To upgrade this module from `v0.4.0` to `v0.5.0`, you need to download this new version, then apply the `kustomize` project. No further action is required.
+To upgrade this module from `v0.5.0` to `vTBD`, you need to download this new version, then apply the `kustomize` project. No further action is required.
 
 ```bash
 kustomize build | kubectl apply -f -

--- a/katalog/gangplank/html-templates/commandline.tmpl
+++ b/katalog/gangplank/html-templates/commandline.tmpl
@@ -1,73 +1,99 @@
 <!DOCTYPE html>
-<html lang="en">
+<html>
+
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
-  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0"/>
-  <title>Kubernetes Fury Distribution - OIDC Login</title>
-  <!-- CSS  -->
-  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.100.2/css/materialize.min.css">
-
-  <!-- Prism -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.14.0/prism.min.js" integrity="sha256-jTGzLAqOAcOL+ALD2f2tvFY7fs6dwkOeo88xiuVHaRk=" crossorigin="anonymous"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.14.0/components/prism-bash.min.js" integrity="sha256-Ch5rv5tgAdVMCh7Wqb0UOcXkQAHNFSezi+0v/0z6xfw=" crossorigin="anonymous"></script>
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.14.0/themes/prism-tomorrow.min.css" integrity="sha256-4S9ufRr1EqaUFFeM9/52GH68Hs1Sbvx8eFXBWpl8zPI=" crossorigin="anonymous" />
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.14.0/plugins/toolbar/prism-toolbar.min.css" integrity="sha256-xY7/SUa769r0PZ1ytZPFj2WqnOZYaYSKbX1hVTiQlcA=" crossorigin="anonymous" />
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.14.0/plugins/toolbar/prism-toolbar.min.js" integrity="sha256-OvKYJLcYRP3ZIPilT03rynyZfkdGFwzCwU82NB4/AT4=" crossorigin="anonymous"></script>  
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.0/clipboard.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.14.0/plugins/copy-to-clipboard/prism-copy-to-clipboard.min.js" integrity="sha256-s+Z1sBUQFaaw7xeAnWb/oS8gBM4MEKiEWMRJ0p+/xbc=" crossorigin="anonymous"></script>
+  <meta charset="utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <title>SIGHUP Distribution - OIDC Login</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:slnt,wght@-10,300..700;0,300..700&family=Roboto+Mono:ital,wght@0,400..700;1,400..700&display=swap"
+    rel="stylesheet" />
+  <link rel="stylesheet" type="text/css" media="screen" href="{{ .HTTPPath }}/static/style.css" />
 </head>
-    <body>
-        <nav style="background-color: rgb(66,25,89);" role="navigation">
-            <div class="nav-wrapper container"><a id="logo-container" href="#" class="brand-logo">Kubernetes Fury Distribution</a>
-            <ul class="right hide-on-med-and-down">
-                <li><a href="{{ .HTTPPath }}/logout">Logout</a></li>
-            </ul>
 
-            <ul id="nav-mobile" class="side-nav">
-                <li><a href="#">Decode JWT</a></li>
-            </ul>
-            <a href="#" data-activates="nav-mobile" class="button-collapse"><i class="material-icons">menu</i></a>
+<body style="height: 100%">
+  <div class="euiFlexGroup euiFlexGroup-l-flexStart-stretch-column" style="height: 100%">
+    <div class="euiFlexItem euiFlexItem-growZero">
+      <div class="euiHeader euiHeader-static-default" style="padding: 40px 30px">
+        <div class="euiFlexGroup euiFlexGroup-l-center-stretch-column">
+          <div class="euiFlexItem euiFlexItem-growZero align-items-center">
+            <div class="euiText euiText-m">
+              <h1>SIGHUP Distribution - OIDC Login</h1>
             </div>
-        </nav>
-        <div class="container">
-            <h4 class="header center darken-3">
-                Welcome {{ .Username }}.
-            </h4>
-            <h5>
-                In order to get command-line access to the {{ .ClusterName }} Kubernetes cluster, you will need to configure OpenID Connect (OIDC) authentication for your client.
-            </h5>
-            <br>
-            <p>
-                The Kubernetes command-line utility, kubectl, may be installed like so:
-            </p>
-           <pre>
-             <code class="language-bash">
-$ curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/$(uname | awk '{print tolower($0)}')/amd64/kubectl
-$ chmod +x ./kubectl
-$ sudo mv ./kubectl /usr/local/bin/kubectl
-             </code>
-           </pre>
-            <div class="row">
-                <div class="col s12 right-align"><a href="{{ .HTTPPath }}/kubeconf" class="btn-large waves-effect waves-light purple darken-4">Download Kubeconfig</a></div>
-                <div class="col s12">Once kubectl is installed, you may execute the following:</div>
-            </div>
-            <pre>
-               <code class="language-bash">
-echo "{{ .ClusterCA }}" \ > "ca-{{ .ClusterName }}.pem"
-kubectl config set-cluster "{{ .ClusterName }}" --server={{ .APIServerURL }} --certificate-authority="ca-{{ .ClusterName }}.pem" --embed-certs
-kubectl config set-credentials "{{ .KubeCfgUser }}"  \
-    --auth-provider=oidc  \
-    --auth-provider-arg='idp-issuer-url={{ .IssuerURL }}'  \
-    --auth-provider-arg='client-id={{ .ClientID }}'  \
-    --auth-provider-arg='client-secret={{ .ClientSecret }}' \
-    --auth-provider-arg='refresh-token={{ .RefreshToken }}' \
-    --auth-provider-arg='id-token={{ .IDToken }}'
-kubectl config set-context "{{ .ClusterName }}" --cluster="{{ .ClusterName }}" --user="{{ .KubeCfgUser }}"
-kubectl config use-context "{{ .ClusterName }}"
-rm "ca-{{ .ClusterName }}.pem"
-              </code>
-            </pre>
+          </div>
         </div>
-    </body>
+
+        <div class="euiHeaderSectionItem euiHeaderSectionItem">
+          <nav class="euiHeaderLinks euiHeaderLinks">
+            <div class="euiHeaderLinks__list euiHeaderLinks__list-s-EuiHeaderLinks">
+              <a class="euiButtonEmpty euiHeaderLink euiButtonDisplay-euiButtonEmpty-m-empty-text"
+                href="{{ .HTTPPath }}/logout" rel="noreferrer">
+                <span class="euiButtonEmpty__content euiButtonDisplayContent">
+                  <span class="eui-textTruncate euiButtonEmpty__text">
+                    Logout
+                  </span>
+                </span>
+              </a>
+            </div>
+          </nav>
+        </div>
+      </div>
+    </div>
+    <div class="euiFlexItem euiFlexItem-grow-1" style="padding: 40px">
+      <div class="euiFlexGroup euiFlexGroup-l-center-center-column">
+        <div class="euiFlexItem euiFlexItem-growZero">
+          <div class="euiText euiText-m-euiTextAlign-center">
+            <h1>Welcome {{ .Username }}.</h1>
+            <p>
+              In order to get command-line access to the
+              {{ .ClusterName }} Kubernetes cluster, you will need to
+              configure OpenID Connect (OIDC) authentication for your client.
+            </p>
+          </div>
+        </div>
+        <div class="euiFlexItem euiFlexItem-growZero">
+          <a href="{{ .HTTPPath }}/kubeconf" rel="noreferrer"
+            class="euiButton euiButtonDisplay-m-defaultMinWidth-base-primary">
+            <span class="euiButtonDisplayContent">
+              <span class="eui-textTruncate">Download Kubeconfig</span>
+            </span>
+          </a>
+        </div>
+        <div class="euiFlexItem euiFlexItem-growZero">
+          <div class="euiText euiText-m-euiTextAlign-center">
+            <p>Or you can execute the following commands:</p>
+          </div>
+        </div>
+        <div class="euiFlexItem euiFlexItem-growZero full-width">
+          <div class="euiCodeBlock euiCodeBlock-m">
+            <pre class="euiCodeBlock__pre euiCodeBlock__pre-preWrap-padding" tabindex="-1">
+                <code class="euiCodeBlock__code euiCodeBlock__code">
+                  {{ if not (eq .ClusterCA  "") }}
+                  <span class="euiCodeBlock__line">echo "{{ .ClusterCA }}" \ > "ca-{{ .ClusterName }}.pem"</span>
+                  {{ end }}
+                  <span class="euiCodeBlock__line">kubectl config set-cluster "{{ .ClusterName }}" --server={{ .APIServerURL }}{{ if not (eq .ClusterCA  "") }} --certificate-authority="ca-{{ .ClusterName }}.pem" --embed-certs{{ end }}</span>
+                  <span class="euiCodeBlock__line">kubectl config set-credentials "{{ .KubeCfgUser }}"  \
+    --auth-provider=oidc  \
+    --auth-provider-arg="idp-issuer-url={{ .IssuerURL }}"  \
+    --auth-provider-arg="client-id={{ .ClientID }}"  \
+    --auth-provider-arg="client-secret={{ .ClientSecret }}" \
+    --auth-provider-arg="refresh-token={{ .RefreshToken }}" \
+    --auth-provider-arg="id-token={{ .IDToken }}" {{ if not (eq .IDPCAb64  "") }}\
+    --auth-provider-arg="idp-certificate-authority-data={{ .IDPCAb64 }}" \
+    {{ end }}
+                  </span> 
+                  <span class="euiCodeBlock__line">kubectl config set-context "{{ .ClusterName }}" --cluster="{{ .ClusterName }}" --user="{{ .KubeCfgUser }}" {{ if not (eq .Namespace "") }}--namespace="{{ .Namespace }}"{{ end }}</span>
+                  <span class="euiCodeBlock__line">kubectl config use-context "{{ .ClusterName }}"</span>
+                  {{ if not (eq .ClusterCA  "") }}<span class="euiCodeBlock__line">rm "ca-{{ .ClusterName }}.pem"</span>{{ end }}
+                  {{ if not (eq .IDPCA  "") }}<span class="euiCodeBlock__line">rm "ca-idp-{{ .ClusterName }}.pem"</span>{{ end }}
+                </code>
+              </pre>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+
 </html>

--- a/katalog/gangplank/html-templates/home.tmpl
+++ b/katalog/gangplank/html-templates/home.tmpl
@@ -1,66 +1,65 @@
 <!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
-  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0"/>
-  <title>Kubernetes Fury Distribution - OIDC Login</title>
-
-  <!-- CSS  -->
-  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.100.2/css/materialize.min.css">
-  <style>
-    pre.bash {
-        background-color: black;
-        color: #49fb35;
-        font-size: small;
-        font-family: Consolas,Monaco,Lucida Console,Liberation Mono,DejaVu Sans Mono,Bitstream Vera Sans Mono,Courier New, monospace;
-        overflow: auto;
-        word-wrap: normal;
-        white-space: pre;
-    }
-
-    .icon-block {
-    padding: 0 15px;
-    }
-    .icon-block .material-icons {
-        font-size: inherit;
-    }
-</style>
-</head>
-<body>
-  <nav style="background-color: rgb(66,25,89);" role="navigation">
-    <div class="nav-wrapper container"><a id="logo-container" href="#" class="brand-logo">Kubernetes Fury Distribution</a>
-      <ul class="right hide-on-med-and-down">
-
-      </ul>
-
-      <ul id="nav-mobile" class="side-nav">
-
-      </ul>
-      <a href="#" data-activates="nav-mobile" class="button-collapse"><i class="material-icons">menu</i></a>
-    </div>
-  </nav>
-  <div class="section no-pad-bot" id="index-banner">
-    <div class="container">
-      <br><br>
-      <h1 class="header center darken-3">Kubernetes Fury Distribution Authentication</h1>
-      <div class="row center">
-        <h5 class="header col s12 light">This utility will help you authenticate with your Kubernetes cluster with an OpenID Connect (OIDC) flow. Sign in to get started.</h5>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <title>SIGHUP Distribution - OIDC Login</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:slnt,wght@-10,300..700;0,300..700&family=Roboto+Mono:ital,wght@0,400..700;1,400..700&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      type="text/css"
+      media="screen"
+      href="{{ .HTTPPath }}/static/style.css"
+    />
+  </head>
+  <body style="height: 100%">
+    <div
+      class="euiFlexGroup euiFlexGroup-l-flexStart-stretch-column"
+      style="height: 100%"
+    >
+      <div class="euiFlexItem euiFlexItem-growZero">
+        <div
+          class="euiHeader euiHeader-static-default"
+          style="padding: 40px 0px"
+        >
+          <div class="euiFlexGroup euiFlexGroup-l-center-center-column">
+            <div class="euiFlexItem euiFlexItem-growZero">
+              <div class="euiText euiText-m">
+                <h1>SIGHUP Distribution - OIDC Login</h1>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
-      <div class="row center">
-        <a href="{{ .HTTPPath }}/login" id="download-button" class="btn-large waves-effect waves-light purple darken-4">Sign In</a>
+      <div class="euiFlexItem euiFlexItem-grow-1" style="padding: 40px">
+        <div class="euiFlexGroup euiFlexGroup-l-center-center-column">
+          <div class="euiFlexItem euiFlexItem-growZero">
+            <div class="euiText euiText-m-euiTextAlign-center">
+              <h1>SIGHUP Distribution Authentication</h1>
+              <p>
+                This utility will help you authenticate with your Kubernetes
+                cluster with an OpenID Connect (OIDC) flow. Sign in to get
+                started.
+              </p>
+            </div>
+          </div>
+          <div class="euiFlexItem euiFlexItem-growZero">
+            <a
+              href="{{ .HTTPPath }}/login"
+              rel="noreferrer"
+              class="euiButton euiButtonDisplay-m-defaultMinWidth-base-primary"
+            >
+              <span class="euiButtonDisplayContent">
+                <span class="eui-textTruncate">Sign in</span>
+              </span>
+            </a>
+          </div>
+        </div>
       </div>
-      <br><br>
-
     </div>
-  </div>
-
-
-  <!--  Scripts-->
-  <script src="https://code.jquery.com/jquery-2.1.1.min.js"></script>
-  <!-- These two scripts are called in the original template, but they are not to be found in Gangplank's container image.
-  <script src="js/materialize.js"></script>
-  <script src="js/init.js"></script>
-  -->
   </body>
 </html>

--- a/katalog/gangplank/kustomization.yaml
+++ b/katalog/gangplank/kustomization.yaml
@@ -15,4 +15,4 @@ configMapGenerator:
 
 images:
   - name: registry.sighup.io/fury/gangplank
-    newTag: "1.1.0"
+    newTag: "1.1.1"


### PR DESCRIPTION
### Summary 💡

This PR updates the Gangplank package to the latest version `v1.1.1`.

Relates: [gangplank/pull/10](https://github.com/sighupio/gangplank/pull/10)


### Description 📝

This is to align the module with the latest version of Gangplank, which was updated to fix a bug related to IDPs that expose a self-signed certificate (read more: [gangplank/issues/9](https://github.com/sighupio/gangplank/issues/9)).

A new configuration parameter was introduced in Gangplank: `idpCAPath` / `GANGPLANK_CONFIG_IDP_CA_PATH`. This will instruct Gangplank to include the certificate inside the `user` section of the generated kubeconfig, so refresh-token flows will work properly with self-signed certificates.

### Breaking Changes 💔

None.

### Tests performed 🧪

- [x] Tested the change with SD version 1.31.1
- [x] Tested an upgrade from the previous version 0.5.0

### Future work 🔧

We could add a new section inside the furyctl config file to customize Gangplank from there, instead of relying on custom patches.